### PR TITLE
Mobile friendly nav

### DIFF
--- a/src/components/NavBar/MobileMenu/MobileMenu.css
+++ b/src/components/NavBar/MobileMenu/MobileMenu.css
@@ -51,15 +51,15 @@
               opacity 0.55s ease;
 }
 
-.nav-mobile-toggle input:checked ~ span:nth-last-child(3) {
+.nav-mobile-toggle input.checked ~ span:nth-last-child(3) {
     transform: rotate(45deg);
     height: 3px;
 }
-.nav-mobile-toggle input:checked ~ span:nth-last-child(2) {
+.nav-mobile-toggle input.checked ~ span:nth-last-child(2) {
     opacity: 0;
 }
 
-.nav-mobile-toggle input:checked ~ span:nth-last-child(1) {
+.nav-mobile-toggle input.checked ~ span:nth-last-child(1) {
     transform: rotate(-45deg);
     height: 3px;
 }

--- a/src/components/NavBar/MobileMenu/MobileMenu.css
+++ b/src/components/NavBar/MobileMenu/MobileMenu.css
@@ -1,14 +1,15 @@
 .nav-links {
     position: absolute;
     top: 4.5rem; /* for some reason this is always offset downwards by 0.5rem, which is exactly the width of the navbar's border (in mobile mode). idk why. temp fix. */
-    width: 100%;
+    width: 70%;
     left: 100vw;
     height: calc(100vh - 5rem); /* 8rem is the height of the navbar */
     display: flex;
     flex-direction: column;
-    justify-content: space-around;
+    justify-content: start;
     align-items: center;
     background: #f6de98;
+    box-shadow: 0 0 1rem #85888C;
 }
 
 
@@ -70,12 +71,12 @@
         left: 100vw;
     }
     100% {
-        left: 0;
+        left: 30vw;
     }
 }
 @keyframes slideOut {
     0% {
-        left: 0;
+        left: 30vw;
     }
     100% {
         left: 100vw;
@@ -84,7 +85,7 @@
 
 .inView {
     animation: slideIn 0.4s ease-in-out;
-    left: 0;
+    left: 30vw;
 }
 .outOfView {
     animation: slideOut 0.4s ease-in-out;

--- a/src/components/NavBar/MobileMenu/MobileMenu.css
+++ b/src/components/NavBar/MobileMenu/MobileMenu.css
@@ -1,9 +1,9 @@
 .nav-links {
     position: absolute;
-    top: 6.7rem; /* for some reason this is always offset downwards by 1.3 rem, which is exactly the width of the navbar's border. idk why. temp fix. */
+    top: 4.5rem; /* for some reason this is always offset downwards by 0.5rem, which is exactly the width of the navbar's border (in mobile mode). idk why. temp fix. */
     width: 100%;
     left: 100vw;
-    height: calc(100vh - 8rem); /* 8rem is the height of the navbar */
+    height: calc(100vh - 5rem); /* 8rem is the height of the navbar */
     display: flex;
     flex-direction: column;
     justify-content: space-around;
@@ -40,12 +40,12 @@
     display: flex;
     width: 2rem;
     height: 3px;
-    margin-bottom: 5px;
+    margin: 2px 0;
     border-radius: 3px;
     position: relative;
     background: #24347b;
     z-index: 1;
-    transform-origin: 17%;
+    transform-origin: 19%;
     transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0),
               background 0.5s cubic-bezier(0.77,0.2,0.05,1.0),
               opacity 0.55s ease;

--- a/src/components/NavBar/MobileMenu/MobileMenu.jsx
+++ b/src/components/NavBar/MobileMenu/MobileMenu.jsx
@@ -11,15 +11,16 @@ const MobileMenu = () => {
     const [isOpen, setIsOpen] = useState(false);
     const [firstOpen, setFirstOpen] = useState(false);
     
-    const openMenu = () => {
+    const toggleMenu = () => {
         setIsOpen(!isOpen);
         setFirstOpen(true);
+        SmoothScroll();
     }
 
     return (
         <>
             <div className="nav-mobile-toggle">
-                <input onClick={openMenu} type="checkbox" />
+                <input onClick={toggleMenu} className={isOpen ? "checked" : ""} type="checkbox" />
                     <span></span>
                     <span></span>
                     <span></span>
@@ -27,10 +28,10 @@ const MobileMenu = () => {
             {/* This complicated looking nested ternary is because we don't want the mobile nav to do the slideOut animation unless clicked on.
                 Without this, the user sees the mobile nav slide out on page load, which looks unprofessional and janky. */}
             <div className={`nav-links ${(firstOpen ? (isOpen ? "inView" : "outOfView") : "")}`}>
-                <NavLink to='/' className ="nav-link" onClick={SmoothScroll}><p>Home</p></NavLink>
-                <NavLink to='/about-us' className ="nav-link" onClick={SmoothScroll}><p>About Us</p></NavLink>
-                <NavLink to='/events' className ="nav-link" onClick={SmoothScroll}><p>Events</p></NavLink>
-                <NavLink to='/join-us' className ="nav-link" onClick={SmoothScroll}><p>Join Us</p></NavLink>
+                <NavLink to='/' className ="nav-link" onClick={toggleMenu}><p>Home</p></NavLink>
+                <NavLink to='/about-us' className ="nav-link" onClick={toggleMenu}><p>About Us</p></NavLink>
+                <NavLink to='/events' className ="nav-link" onClick={toggleMenu}><p>Events</p></NavLink>
+                <NavLink to='/join-us' className ="nav-link" onClick={toggleMenu}><p>Join Us</p></NavLink>
             </div>
         </>
     )

--- a/src/components/NavBar/Navbar.css
+++ b/src/components/NavBar/Navbar.css
@@ -33,6 +33,11 @@
     font-size: min(6vw, 1.75rem);
 }
 
+.nav-link:hover p {
+    color: #47579d;
+    /* transition: 0.2s; */
+}
+
 
 
 

--- a/src/components/NavBar/Navbar.css
+++ b/src/components/NavBar/Navbar.css
@@ -47,10 +47,12 @@
 }
 
 
-/* TABLET MODE IN PORTRAIT/PHONES */
+/* TABLET/PHONES */
 @media screen and (max-width: 850px) {
     .nav-bar {
         padding: 0 1rem;
+        height: 5rem;
+        border-width: 0.5rem;
     }
     .nav-container {
         display: none;


### PR DESCRIPTION
The mobile nav flyout hamburger menu 360 noscope pro gamer thingamajigger now only takes up 70% screen width, and the nav links are grouped towards the start. (The previous design had so much white space it looked awkward)

###Old
![image](https://user-images.githubusercontent.com/80471256/183266915-b6854354-ac9f-4ee5-8cae-433d76fe3433.png)

###New
![image](https://user-images.githubusercontent.com/80471256/183266917-17a2aa8b-f3f1-40a2-a2ec-8f3a8fde6d71.png)
