### PR TITLE
Mobile friendly nav

### DIFF
--- a/src/components/NavBar/MobileMenu/MobileMenu.css
+++ b/src/components/NavBar/MobileMenu/MobileMenu.css
@@ -14,6 +14,7 @@
 
 .nav-link__mobile {
     text-decoration: none;
+    margin: 0;
 }
 
 .nav-link__mobile p {
@@ -21,6 +22,7 @@
     font-family: 'DM Sans';
     font-size: min(6vw, 1.75rem);
     transition: 0.2s;
+    margin: 0;
 }
 
 .nav-link__mobile p:hover{

--- a/src/components/NavBar/MobileMenu/MobileMenu.css
+++ b/src/components/NavBar/MobileMenu/MobileMenu.css
@@ -6,7 +6,7 @@
     height: 100vh;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: space-around;
     align-items: center;
     background: #24347b;
     box-shadow: 0 0 1rem #85888C;
@@ -14,7 +14,6 @@
 
 .nav-link__mobile {
     text-decoration: none;
-    margin: 2rem 0;
 }
 
 .nav-link__mobile p {

--- a/src/components/NavBar/Navbar.css
+++ b/src/components/NavBar/Navbar.css
@@ -20,7 +20,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    width: 50%;
+    width: 60%;
     height: 100%;
 }
 
@@ -53,7 +53,7 @@
         padding: 0 3rem;
     }
     .nav-container {
-        width: 65%;
+        width: 80%;
     }
 }
 


### PR DESCRIPTION
- Change spacing of items on desktop nav to account for the new "tips" section.

- Change spacing of the mobile nav's items to account for the "tips" section. Get rid of their margins, since flex-box takes care of spacing them out evenly all by itself.