### PR TITLE
Encapsulate dropdowns page in the <Dropdowns/> element instead of div

### DIFF
--- a/src/components/pages/Events/Events.css
+++ b/src/components/pages/Events/Events.css
@@ -1,6 +1,5 @@
-.events__content {
-    border: 1px solid #525d92;
-    border-radius: 1.5rem;
-    overflow: hidden;
-    width: 100%;
+.events {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }

--- a/src/components/pages/Events/Events.jsx
+++ b/src/components/pages/Events/Events.jsx
@@ -1,25 +1,27 @@
 import Dropdown from '../../Dropdown/Dropdown';
+import Dropdowns from '../../Dropdown/Dropdowns';
 import './Events.css';
 
 const Events = () => {
     return (
       <div className="custom-background">
         <div className="events">
-          <h2>Events</h2>
-          <div className="events__content">
+          <h1>Events</h1>
+          <Dropdowns>
             <Dropdown 
               title="Commuter Buddy Social – Fall Edition" 
               content={[<>Coming Soon!</>]} 
-            />
+              />
             <Dropdown 
               title="Commuter Buddy Social – Winter Edition" 
               content={[<>Coming Soon!</>]} 
-            />
+              />
             <Dropdown 
               title="Commuter Exam Strategy Session" 
               content={[<>Coming Soon!</>]} 
-            />
-          </div>
+              />
+          </Dropdowns >
+          
         </div>
       </div>
     );


### PR DESCRIPTION
also, doing this resulted in the carets overlapping the text, so I fixed that by reverting a couple commits and stuff.