### PR TITLE
Buddy program form

### DIFF
--- a/src/components/pages/AboutUs/Aboutus.css
+++ b/src/components/pages/AboutUs/Aboutus.css
@@ -2,13 +2,6 @@
     margin-bottom: 4rem;
 }
 
-.section-title {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    margin-bottom: 2rem;
-}
-
 .about-us__team {
     text-align: center;
 }

--- a/src/components/pages/JoinUs/Joinus.css
+++ b/src/components/pages/JoinUs/Joinus.css
@@ -2,5 +2,24 @@
   width: 100%;
   height: 100%;
   border: none;
-  margin-bottom: 5rem;
+  margin-bottom: 7rem;
+  display: flex;
+  justify-content: center;
 }
+
+.formContainer {
+  width: 50%;
+}
+
+
+@media screen and (max-width: 1500px) {
+  .formContainer {
+    width: 75%;
+  }
+}
+@media screen and (max-width: 1000px) {
+  .formContainer {
+    width: 100%;
+  }
+}
+

--- a/src/components/pages/JoinUs/Joinus.css
+++ b/src/components/pages/JoinUs/Joinus.css
@@ -2,5 +2,5 @@
   width: 100%;
   height: 100%;
   border: none;
-  
+  margin-bottom: 5rem;
 }

--- a/src/components/pages/JoinUs/Joinus.css
+++ b/src/components/pages/JoinUs/Joinus.css
@@ -2,7 +2,7 @@
   width: 100%;
   height: 100%;
   border: none;
-  margin-bottom: 7rem;
+  margin-bottom: 5rem;
   display: flex;
   justify-content: center;
 }

--- a/src/components/pages/JoinUs/Joinus.jsx
+++ b/src/components/pages/JoinUs/Joinus.jsx
@@ -13,6 +13,16 @@ const JoinUs = () => {
             <div className="formEmbed">
               <iframe title="formEmbed" src="https://docs.google.com/forms/d/e/1FAIpQLSdRJYQjh4D_NohNCoTX7emkSbLzkBCnO6Kjkrs0o3Eu9wrBAw/viewform?embedded=true" width="100%" height="700" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
             </div>
+            
+            
+            <div className="section-title">
+                  <h1>Commuter Buddy Program Signup</h1>
+                  <p><strong>Don't hesitate! Sign up now!</strong> Sign ups close <strong>September 30th</strong> (subject to change)</p>
+            </div>
+
+            <div className="formEmbed">
+              <iframe title="formEmbed" src="https://docs.google.com/forms/d/e/1FAIpQLSdRJYQjh4D_NohNCoTX7emkSbLzkBCnO6Kjkrs0o3Eu9wrBAw/viewform?embedded=true" width="100%" height="700" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+            </div>
         </div>
         <Footer/>
       </Background>

--- a/src/components/pages/JoinUs/Joinus.jsx
+++ b/src/components/pages/JoinUs/Joinus.jsx
@@ -7,13 +7,15 @@ const JoinUs = () => {
       <Background>
         <div className="join-us">
             <div className="section-title">
-                  <h1>Membership From</h1>
+                  <h1>Membership Form</h1>
             </div>
 
             <div className="formEmbed">
-              <iframe title="formEmbed" src="https://docs.google.com/forms/d/e/1FAIpQLSdRJYQjh4D_NohNCoTX7emkSbLzkBCnO6Kjkrs0o3Eu9wrBAw/viewform?embedded=true" width="100%" height="700" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+                <div className="formContainer">
+                  <iframe title="formEmbed" src="https://docs.google.com/forms/d/e/1FAIpQLSdRJYQjh4D_NohNCoTX7emkSbLzkBCnO6Kjkrs0o3Eu9wrBAw/viewform?embedded=true" width="100%" height="650" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+                </div>
             </div>
-            
+
             
             <div className="section-title">
                   <h1>Commuter Buddy Program Signup</h1>
@@ -21,7 +23,9 @@ const JoinUs = () => {
             </div>
 
             <div className="formEmbed">
-              <iframe title="formEmbed" src="https://docs.google.com/forms/d/e/1FAIpQLSdRJYQjh4D_NohNCoTX7emkSbLzkBCnO6Kjkrs0o3Eu9wrBAw/viewform?embedded=true" width="100%" height="700" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+                <div className="formContainer">
+                  <iframe title="formEmbed" src="https://docs.google.com/forms/d/e/1FAIpQLSdRJYQjh4D_NohNCoTX7emkSbLzkBCnO6Kjkrs0o3Eu9wrBAw/viewform?embedded=true" width="100%" height="700" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+                </div>
             </div>
         </div>
         <Footer/>

--- a/src/index.css
+++ b/src/index.css
@@ -36,6 +36,15 @@ code {
   flex-direction: column;
 }
 
+.section-title {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
 .home, .about-us, .events, .join-us, .tips {
   padding: min(10vh, 5rem) min(6vw, 2rem);
   margin-bottom: 5vh;


### PR DESCRIPTION
Add the Commuter Buddy Program form to the Join us page, right below the membership form. Cry about it later when refactor it into cards.

Jokes aside, this is a temporary fix to get the form up and running and give people the ability to sign up for it. I will later refactor this page to use the Card component (The one seen at the top of the About Us page) that will give information about both the membership navigator thingy and the commuter buddy programs, and will have a link that redirects to the pages with the respective forms.